### PR TITLE
Support default values

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,20 @@ const config = conform(process.env, schema)
 module.exports = config
 ```
 
+#### Default Values
+
+You can supply the environment with a default value to a variable if such variable doesn't exist. If it does, the value from the environment variable will be used.
+
+```js
+const schema = {
+  DEFAULT_LOCALE: string,
+  SUPPORTED_LOCALES: array,
+  TOKEN_EXPIRATION: 3600, // in secs
+}
+```
+
+This is particularly useful when you have some constant (here we have the token expiration in seconds) that is being used in more places over your code and will need to be changed occasionally without intervening the code (eg. in testing environment).
+
 ## Other Tools
 
 - https://www.npmjs.com/package/getenv — Slightly different concept, very good solution.

--- a/index.js
+++ b/index.js
@@ -30,18 +30,19 @@ const object = (s) => s
 
 const conform = (env, schema) => {
   return Object.keys(schema).reduce((acc, key) => {
-    const transform = schema[key]
-    const type = typeof transform
+    const val = schema[key]
+
+    const type = Array.isArray(val)
+      ? "array"
+      : typeof val
 
     if (type !== "function") {
-      throw new Error(
-        `Invalid schema. Conversion functions should be provided in ` +
-        `the schema object. Instead saw type "${type}" at the ` +
-        `"${key}" key.`
-      )
+      if (env[key]) acc[key] = eval(`${type}(env[key])`)
+      else acc[key] = schema[key]
+    } else {
+      acc[key] = val(env[key])
     }
 
-    acc[key] = transform(env[key])
     return acc
   }, {})
 }

--- a/index.test.js
+++ b/index.test.js
@@ -49,6 +49,8 @@ test("conform", (t) => {
     NUMBER: number,
     ARRAY: array,
     OBJECT: object,
+    DEFAULT: "quuz",
+    OVERWRITTEN: ["quux"],
     MISSING: array,
   }
 
@@ -58,6 +60,7 @@ test("conform", (t) => {
     NUMBER: "123",
     ARRAY: "foo, bar, baz",
     OBJECT: "beep:boop, boom:bam",
+    OVERWRITTEN: "qux",
   }
 
   const expected = {
@@ -66,16 +69,12 @@ test("conform", (t) => {
     NUMBER: 123,
     ARRAY: ["foo", "bar", "baz"],
     OBJECT: {beep: "boop", boom: "bam"},
+    DEFAULT: "quuz",
+    OVERWRITTEN: ["qux"],
     MISSING: [],
   }
 
   const result = conform(env, schema)
 
   t.deepEqual(result, expected)
-
-  const badSchema = {
-    STRING: "not a function",
-  }
-
-  t.throws(() => conform(env, badSchema))
 })


### PR DESCRIPTION
IMHO it might be useful to support _default values_ for environment variables that should be in environment but it would take too much effort to specify all of them everytime you create an environment.

As an example, imagine that we have `TOKEN_EXPIRATION` constant that is being used in my code. I don't usually need to have different values for different environments but I'd still prefer to have it not baked in the code but rather have it as an env variable in case I wanted to actually test the feature of token expiring correctly (and not waiting an hour for token to expire).

What do you think?